### PR TITLE
79 star component

### DIFF
--- a/src/assets/svg/star.svg
+++ b/src/assets/svg/star.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="15.219px" viewBox="0 0 16 15.219" enable-background="new 0 0 16 15.219" xml:space="preserve">
+<g id="star_x5F_fil">
+	<g id="star_x5F_lin">
+		<path d="M8,2.819l1.396,2.829l0.279,0.566L10.3,6.304l3.121,0.453l-2.258,2.2l-0.451,0.44l0.106,0.621l0.533,3.113l-2.793-1.47
+			L8,11.369l-0.559,0.293l-2.795,1.47l0.534-3.112l0.106-0.622l-0.451-0.44l-2.257-2.2l3.12-0.453l0.625-0.091l0.279-0.565L8,2.819
+			 M8,0.107l-2.473,5.01L0,5.919l3.998,3.897l-0.945,5.509L8,12.725l4.944,2.601l-0.943-5.509L16,5.919l-5.528-0.802L8,0.107
+			L8,0.107z"/>
+	</g>
+</g>
+</svg>

--- a/src/assets/svg/starFilled.svg
+++ b/src/assets/svg/starFilled.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="15.219px" viewBox="0 0 16 15.219" enable-background="new 0 0 16 15.219" xml:space="preserve">
+<g id="star_x5F_fil">
+	<polygon points="8,0 10.472,5.009 16,5.812 12.001,9.71 12.944,15.219 8,12.619 3.053,15.219 3.997,9.71 0,5.812 5.526,5.009 	"/>
+	<g id="star_x5F_lin">
+	</g>
+</g>
+</svg>

--- a/src/components/Star/Star.md
+++ b/src/components/Star/Star.md
@@ -1,0 +1,22 @@
+Examples:
+
+Star active by default
+```js
+    <Star :active="true" />
+```
+
+Star inactive by default
+```js
+    <Star :active="true" />
+```
+
+
+
+
+
+
+
+
+
+
+

--- a/src/components/Star/Star.md
+++ b/src/components/Star/Star.md
@@ -2,7 +2,7 @@ Examples:
 
 Star active
 ```js
-    <Star :active />
+    <Star active />
 ```
 
 Star inactive

--- a/src/components/Star/Star.md
+++ b/src/components/Star/Star.md
@@ -2,7 +2,7 @@ Examples:
 
 Star active
 ```js
-    <Star :active="true" />
+    <Star :active />
 ```
 
 Star inactive

--- a/src/components/Star/Star.md
+++ b/src/components/Star/Star.md
@@ -1,13 +1,13 @@
 Examples:
 
-Star active by default
+Star active
 ```js
     <Star :active="true" />
 ```
 
-Star inactive by default
+Star inactive
 ```js
-    <Star :active="true" />
+    <Star  />
 ```
 
 

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="star">
-    <svgicon :name="star" />
-  </div>
+  <svgicon class="star" @click="isActive = !isActive" :name="isActive || active ? 'starFilled' : 'star'" />
 </template>
 
 <script>
@@ -15,29 +13,12 @@ export default {
       default: false
     }
   },
-  data: function() {
-    if (this.active) {
-      return {
-        star: 'starFilled'
-      }
-    } else {
-      return {
-        star: 'star'
-      }
-    }
-  },
-  methods: {
-    fill: function() {
-      this.active = true
-    }
-  }
+  data: () => ({ isActive: false })
 }
 </script>
 
 <style lang="scss" scoped>
-.star:hover:before {
-   content: "\2605";
-   padding-top:config('padding.2px');
-   position: absolute;
+.star {
+  cursor: pointer;
 }
 </style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="active ? 'defaultActive' : ''"
+    :class="active ? 'is-active' : ''"
     class="star">
     <svgicon
       :name="(active || hoverState) ? 'starFilled' : 'star'"
@@ -31,7 +31,7 @@ export default {
   color: config('colors.star');
 }
 
-.defaultActive {
+.is-active {
   color: config('colors.white');
 }
 </style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="star">
-    <svgicon v-bind:name="star" />
+    <svgicon :name="star" />
   </div>
 </template>
 
@@ -20,8 +20,7 @@ export default {
       return {
         star: 'starFilled'
       }
-    }
-    else {
+    } else {
       return {
         star: 'star'
       }
@@ -38,7 +37,7 @@ export default {
 <style lang="scss" scoped>
 .star:hover:before {
    content: "\2605";
-   padding-top:2px;
+   padding-top:config('padding.2px');
    position: absolute;
 }
 </style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,0 +1,27 @@
+<template>
+  <div
+    :class="{
+      'filled': active === true
+    }"
+    class="star">
+    <span>☆</span>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    active: {
+      type: Boolean,
+      default: true
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.star > span:hover:before {
+   content: "\2605";
+   position: absolute;
+}
+</style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,8 +1,10 @@
 <template>
-  <svgicon
-    :name="active ? 'starFilled' : 'star'"
-    class="star"
-  />
+  <div class="star">
+    <svgicon
+      :name="active ? 'starFilled' : 'star'"
+      class="star"
+    />
+  </div>
 </template>
 
 <script>
@@ -23,5 +25,11 @@ export default {
 .star {
   cursor: pointer;
   color: #a7a9ac;
+}
+
+.star:hover:before {
+  content: '★';
+  padding-top: 2px;
+  position: absolute;
 }
 </style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,5 +1,8 @@
 <template>
-  <svgicon class="star" @click="isActive = !isActive" :name="isActive || active ? 'starFilled' : 'star'" />
+  <svgicon
+    :name="isActive || active ? 'starFilled' : 'star'"
+    class="star"
+    @mouseover.native="isActive = true" @mouseleave.native="isActive = false" />
 </template>
 
 <script>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="{
-      'filled': active === true
+      'filled': active
     }"
     class="star">
     <span>☆</span>
@@ -13,7 +13,7 @@ export default {
   props: {
     active: {
       type: Boolean,
-      default: true
+      default: false
     }
   }
 }

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,27 +1,44 @@
 <template>
-  <div
-    :class="{
-      'filled': active
-    }"
-    class="star">
-    <span>☆</span>
+  <div class="star">
+    <svgicon v-bind:name="star" />
   </div>
 </template>
 
 <script>
+import '@icons/star'
+import '@icons/starFilled'
+
 export default {
   props: {
     active: {
       type: Boolean,
       default: false
     }
+  },
+  data: function() {
+    if (this.active) {
+      return {
+        star: 'starFilled'
+      }
+    }
+    else {
+      return {
+        star: 'star'
+      }
+    }
+  },
+  methods: {
+    fill: function() {
+      this.active = true
+    }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-.star > span:hover:before {
+.star:hover:before {
    content: "\2605";
+   padding-top:2px;
    position: absolute;
 }
 </style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="star">
     <svgicon
-      :name="active ? 'starFilled' : 'star'"
+      :name="(active || hoverState) ? 'starFilled' : 'star'"
+      @mouseover.native="hoverState=true" @mouseleave.native="hoverState=false"
     />
   </div>
 </template>
@@ -16,7 +17,8 @@ export default {
       type: Boolean,
       default: false
     }
-  }
+  },
+  data: () => ({ hoverState: false })
 }
 </script>
 
@@ -24,10 +26,5 @@ export default {
 .star {
   cursor: pointer;
   color: config('colors.star');
-}
-
-.star:hover {
-  content: '★';
-  position: absolute;
 }
 </style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,8 +1,8 @@
 <template>
   <svgicon
-    :name="isActive || active ? 'starFilled' : 'star'"
+    :name="active ? 'starFilled' : 'star'"
     class="star"
-    @mouseover.native="isActive = true" @mouseleave.native="isActive = false" />
+  />
 </template>
 
 <script>
@@ -15,13 +15,13 @@ export default {
       type: Boolean,
       default: false
     }
-  },
-  data: () => ({ isActive: false })
+  }
 }
 </script>
 
 <style lang="scss" scoped>
 .star {
   cursor: pointer;
+  color: #a7a9ac;
 }
 </style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -2,7 +2,6 @@
   <div class="star">
     <svgicon
       :name="active ? 'starFilled' : 'star'"
-      class="star"
     />
   </div>
 </template>
@@ -24,12 +23,11 @@ export default {
 <style lang="scss" scoped>
 .star {
   cursor: pointer;
-  color: #a7a9ac;
+  color: config('colors.star');
 }
 
-.star:hover:before {
+.star:hover {
   content: '★';
-  padding-top: 2px;
   position: absolute;
 }
 </style>

--- a/src/components/Star/Star.vue
+++ b/src/components/Star/Star.vue
@@ -1,8 +1,11 @@
 <template>
-  <div class="star">
+  <div
+    :class="active ? 'defaultActive' : ''"
+    class="star">
     <svgicon
       :name="(active || hoverState) ? 'starFilled' : 'star'"
-      @mouseover.native="hoverState=true" @mouseleave.native="hoverState=false"
+      @mouseover.native="hoverState=true"
+      @mouseleave.native="hoverState=false"
     />
   </div>
 </template>
@@ -26,5 +29,9 @@ export default {
 .star {
   cursor: pointer;
   color: config('colors.star');
+}
+
+.defaultActive {
+  color: config('colors.white');
 }
 </style>

--- a/src/components/Star/index.js
+++ b/src/components/Star/index.js
@@ -1,0 +1,2 @@
+import Star from './Star.vue'
+export default Star

--- a/src/views/Components.vue
+++ b/src/views/Components.vue
@@ -15,7 +15,7 @@
             text="button test"
             size="big"
           />
-          <Star :active="true" />
+          <Star />
         </div>
       </Card>
     </div>

--- a/src/views/Components.vue
+++ b/src/views/Components.vue
@@ -15,6 +15,7 @@
             text="button test"
             size="big"
           />
+          <Star :active="true" />
         </div>
       </Card>
     </div>
@@ -45,10 +46,11 @@
 import Button from '@/components/Button/'
 import Tabs from '@/components/Tabs/'
 import Card from '@/components/Card'
+import Star from '@/components/Star'
 
 export default {
   name: 'Components',
-  components: { Button, Tabs, Card },
+  components: { Button, Tabs, Card, Star },
   data() {
     return {
       testString: '',

--- a/tailwind.js
+++ b/tailwind.js
@@ -648,6 +648,7 @@ module.exports = {
 
   padding: {
     'px': '1px',
+    '2px': '2px',
     '0': '0',
     '1': '0.25rem',
     '2': '0.5rem',

--- a/tailwind.js
+++ b/tailwind.js
@@ -141,7 +141,8 @@ let colors = {
   'tab-header': '#7a7675',
   'tab-hover': 'rgba(255, 255, 255, 0.6)',
   'tab-active': '#ffffff',
-  'table-bg': '#000000'
+  'table-bg': '#000000',
+  'star': '#a7a9ac'
 }
 
 module.exports = {

--- a/tailwind.js
+++ b/tailwind.js
@@ -648,7 +648,6 @@ module.exports = {
 
   padding: {
     'px': '1px',
-    '2px': '2px',
     '0': '0',
     '1': '0.25rem',
     '2': '0.5rem',


### PR DESCRIPTION
#### What's this PR do?
The PR renames the branch from 'star-component' to '79-star-component' also adding useful corrections to Star.vue, reference to [the old PR](https://github.com/bitshares/bitshares-community-ui/pull/94) 
#### Where should the reviewer start?
Star.vue
#### How should this be manually tested?
The star should be filled on hover
http://localhost:8080/#/components (if locally)
or
http://staging-ui.trusty.apasia.tech:8080/79-star-component/#/components 

#### Any background context you want to provide?
The star hovers on select, also can be permanently selected from props
#### What are the relevant tickets?
[#79](https://github.com/bitshares/bitshares-community-ui/issues/79)
#### Screenshots (if appropriate)
<img width="72" alt="screen shot 2018-10-21 at 09 10 54" src="https://user-images.githubusercontent.com/26275425/47263803-48f55c80-d511-11e8-8b32-6c5b32f65805.png">


#### URL
Provide a link to your deploy from http://staging-ui.trusty.apasia.tech:8080/79-star-component/#/components
#### Questions:
Hover should be done from CSS or by replacing an icon using js? I had a solution using js.