### PR TITLE
211 markets longer card

### DIFF
--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -210,12 +210,9 @@ export default {
   }
 }
 
-
-
 .header {
   margin-left: auto;
 }
-
 
 .card--collapsed {
   height: 2.8rem;

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -2,7 +2,7 @@
   <div class="card-container h-full">
     <div
       :class="{
-        'card--collapsed': collapsed, 
+        'card--collapsed': collapsed,
         'lg:h-card-long-height': long
       }"
       class="card border-none h-full lg:h-card-height"

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -42,7 +42,8 @@
         </div>
         <svgicon
           v-if="collapsible"
-          :class="collapsed ? 'collapse-btn--active' : 'collapse-btn'"
+          :class="{'collapse-btn--active' : collapsed }"
+          class="collapse-btn"
           width="11"
           height="11"
           name="arrowDown"
@@ -129,17 +130,25 @@ export default {
   background-color: config('colors.card-background');
   border-width: 1px;
   transition: 0.2s;
-}
-
-.card--expanded {
-  height: 35rem;
-  .card-header {
-    padding-right: 2rem;
-    padding-top: 1rem;
-    padding-left: 1.25rem;
-    .title {
-      font-size: config('textSizes.lg')
+  &.card--expanded {
+    height: 35rem;
+    .card-header {
+      padding-right: 2rem;
+      padding-top: 1rem;
+      padding-left: 1.25rem;
+      .title {
+        font-size: config('textSizes.lg')
+      }
     }
+  }
+  &.card--collapsed {
+    height: 2.8rem;
+    transition: 0.2s;
+  }
+  .card-body {
+    @apply pt-3;
+    height: 100%;
+    overflow: hidden;
   }
 }
 
@@ -154,6 +163,23 @@ export default {
   justify-content: space-between;
   align-items: baseline;
   position: relative;
+  .title {
+    font-size: config('textSizes.base');
+    font-family: config('fonts.gotham-medium');
+    text-transform: uppercase;
+    font-size: config('textSizes.base');
+    white-space: nowrap;
+  }
+  .collapse-btn {
+    transform: rotate(-90deg);
+    transition: transform 0.2s;
+    margin: 0 auto 0 0.5em;
+    opacity: 0.8;
+    cursor: pointer;
+    &.collapse-btn--active {
+      transform: none;
+    }
+  }
   .expand-btn {
     top: 0.4rem;
     right: 0.4rem;
@@ -184,37 +210,12 @@ export default {
   }
 }
 
-.title {
-  font-size: config('textSizes.base');
-  font-family: config('fonts.gotham-medium');
-  text-transform: uppercase;
-  font-size: config('textSizes.base');
-  white-space: nowrap;
-}
+
 
 .header {
   margin-left: auto;
 }
 
-.card-body {
-  @apply pt-3;
-  height: 100%;
-  overflow: hidden;
-}
-
-.collapse-btn {
-  transform: rotate(-90deg);
-  transition: 0.2s;
-  margin: 0 auto 0 0.1875em;
-  opacity: 0.8;
-  cursor: pointer;
-}
-
-.collapse-btn--active {
-  margin: 0 auto 0 0.1875em;
-  transition: 0.2s;
-  cursor: pointer;
-}
 
 .card--collapsed {
   height: 2.8rem;

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -132,10 +132,6 @@ export default {
 }
 
 .card--expanded {
-  // height: 35rem;
-  &.card--long {
-    height: 70rem;
-  }
   .card-header {
     padding-right: 2rem;
     padding-top: 1rem;

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -1,8 +1,11 @@
 <template>
-  <div class="card-container mb-card-margin lg:mb-0 h-full">
+  <div class="card-container h-full">
     <div
-      :class="{'card-collapsed': collapsed}"
-      class="card border-none lg:mr-card-margin h-full lg:h-card-height"
+      :class="{
+        'card--collapsed': collapsed, 
+        'lg:h-card-long-height': long
+      }"
+      class="card border-none h-full lg:h-card-height"
     >
       <Modal
         v-if="expanded"
@@ -91,6 +94,10 @@ export default {
     collapsible: {
       type: Boolean,
       default: false
+    },
+    long: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -125,7 +132,10 @@ export default {
 }
 
 .card--expanded {
-  height: 35rem;
+  // height: 35rem;
+  &.card--long {
+    height: 70rem;
+  }
   .card-header {
     padding-right: 2rem;
     padding-top: 1rem;
@@ -208,7 +218,7 @@ export default {
   cursor: pointer;
 }
 
-.card-collapsed {
+.card--collapsed {
   height: 2.8rem;
   transition: 0.2s;
 }

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -132,6 +132,7 @@ export default {
 }
 
 .card--expanded {
+  height: 35rem;
   .card-header {
     padding-right: 2rem;
     padding-top: 1rem;

--- a/src/components/LoadingContainer/LoadingContainer.vue
+++ b/src/components/LoadingContainer/LoadingContainer.vue
@@ -60,7 +60,7 @@ export default ({
   border-radius: 50%;
   width: 36px;
   height: 36px;
-  border: 3px solid rgba(0, 0, 0, 0.1);
+  border: 3px solid rgba(255, 255, 255, 0.1);
   border-top: 3px solid #555;
   animation: rotating 1s infinite linear;
 }

--- a/src/components/LoadingContainer/LoadingContainer.vue
+++ b/src/components/LoadingContainer/LoadingContainer.vue
@@ -51,12 +51,10 @@ export default ({
 .spinner-container {
   display: flex;
   justify-content: center;
-  margin: 40px 0;
-  height: 40px;
-  position: relative;
+  align-items: center;
+  margin-top: 40%;
 }
 .spinner {
-  position: absolute;
   border-radius: 50%;
   width: 36px;
   height: 36px;

--- a/src/components/Spinner/Spinner.vue
+++ b/src/components/Spinner/Spinner.vue
@@ -29,7 +29,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
   @keyframes spinner {
     to {transform: rotate(360deg);}
   }

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -16,6 +16,10 @@ const actions = {
     console.log('init user data')
     const userId = rootGetters['acc/getAccountUserId']
     dispatch('assets/fetchDefaultAssets', null, { root: true })
+    dispatch('orderBook/initialize', {
+      baseSymbol: 'BTS',
+      quoteSymbol: 'USD' },
+    { root: true })
     dispatch('marketsMonitor/initialize', null, { root: true })
     await dispatch('acc/fetchCurrentUser', userId, { root: true })
     // await Promise.all([
@@ -25,12 +29,6 @@ const actions = {
       { userId, limit: 100 },
       { root: true }
     )
-    // ])
-    // const defaultAssetsIds = rootGetters['assets/getDefaultAssetsIds']
-    // defaultAssetsIds.forEach(id => {
-    //   if (balances[id]) return
-    //   balances[id] = { balance: 0 }
-    // })
 
     const balances = { ...rootGetters['acc/getUserBalances'] }
     await dispatch(

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -8,6 +8,7 @@
     </Modal>
     <div class="dashboard hidden lg:block">
       <div class="flex flex-col lg:flex-row mb-card-margin">
+        
         <Card
           :expandable="true"
           collapsible
@@ -23,13 +24,16 @@
             slot="modal"
             :expanded="true"/>
         </Card>
+        
         <Card
           collapsible
           class="lg:w-2/3 disabled"
           title="Graph"
         />
+
       </div>
       <div class="flex flex-col lg:flex-row mb-card-margin">
+        
         <Card
           :expandable="true"
           :long="true"
@@ -44,19 +48,24 @@
             slot="modal"
             :expand-mode="true"/>
         </Card>
+
         <div class="flex lg:w-2/3">
           <div class="flex flex-col lg:w-1/2 mr-card-margin">
+            
             <Card
               collapsible
               title="new order"
               class="mb-card-margin"
             />
+
             <Card
               collapsible
               title="active orders"
             />
+
           </div>
           <div class="flex flex-col lg:w-1/2">
+            
             <Card
               v-if="orderBookIsActive"
               collapsible
@@ -65,6 +74,7 @@
             >
               <OrderBook slot="body"/>
             </Card>
+
             <Card
               :expandable="true"
               title="My orders history"
@@ -76,6 +86,7 @@
                 :expand-mode="true"
               />
             </Card>
+            
           </div>
         </div>
       </div>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -59,6 +59,7 @@
             />
 
             <Card
+              :expandable="true"
               collapsible
               title="active orders"
             >

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -8,7 +8,7 @@
     </Modal>
     <div class="dashboard hidden lg:block">
       <div class="flex flex-col lg:flex-row mb-card-margin">
-        
+
         <Card
           :expandable="true"
           collapsible
@@ -24,7 +24,7 @@
             slot="modal"
             :expanded="true"/>
         </Card>
-        
+
         <Card
           collapsible
           class="lg:w-2/3 disabled"
@@ -33,7 +33,7 @@
 
       </div>
       <div class="flex flex-col lg:flex-row mb-card-margin">
-        
+
         <Card
           :expandable="true"
           :long="true"
@@ -51,7 +51,7 @@
 
         <div class="flex lg:w-2/3">
           <div class="flex flex-col lg:w-1/2 mr-card-margin">
-            
+
             <Card
               collapsible
               title="new order"
@@ -65,7 +65,7 @@
 
           </div>
           <div class="flex flex-col lg:w-1/2">
-            
+
             <Card
               v-if="orderBookIsActive"
               collapsible
@@ -86,7 +86,7 @@
                 :expand-mode="true"
               />
             </Card>
-            
+
           </div>
         </div>
       </div>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -74,7 +74,6 @@
           <div class="flex flex-col lg:w-1/2">
 
             <Card
-              v-if="orderBookIsActive"
               collapsible
               title="order book"
               class="mb-card-margin"
@@ -147,8 +146,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      backupFlag: 'backup/getBackupFlag',
-      orderBookIsActive: 'orderBook/isActive'
+      backupFlag: 'backup/getBackupFlag'
     })
   },
   methods: {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -7,11 +7,11 @@
       <Backup/>
     </Modal>
     <div class="dashboard hidden lg:block">
-      <div class="flex flex-col lg:flex-row mb-2">
+      <div class="flex flex-col lg:flex-row mb-card-margin">
         <Card
           :expandable="true"
           collapsible
-          class="lg:w-1/3"
+          class="lg:w-1/3 lg:mr-card-margin"
           title="account"
         >
           <AccountHeader slot="header"/>
@@ -29,11 +29,12 @@
           title="Graph"
         />
       </div>
-      <div class="flex flex-col lg:flex-row mb-2">
+      <div class="flex flex-col lg:flex-row mb-card-margin">
         <Card
           :expandable="true"
+          :long="true"
           collapsible
-          class="lg:w-1/3"
+          class="lg:w-1/3 lg:mr-card-margin"
           title="markets"
         >
           <MarketsSearch slot="header"/>
@@ -43,25 +44,40 @@
             slot="modal"
             :expand-mode="true"/>
         </Card>
-        <Card
-          v-if="orderBookIsActive"
-          collapsible
-          class="lg:w-1/3"
-          title="order book">
-          <OrderBook slot="body"/>
-        </Card>
-        <Card
-          :expandable="true"
-          class="lg:w-1/3"
-          title="My orders history"
-        >
-          <OrderHistorySearch slot="modal-header"/>
-          <OrderHistory slot="body"/>
-          <OrderHistory
-            slot="modal"
-            :expand-mode="true"
-          />
-        </Card>
+        <div class="flex lg:w-2/3">
+          <div class="flex flex-col lg:w-1/2 mr-card-margin">
+            <Card
+              collapsible
+              title="new order"
+              class="mb-card-margin"
+            />
+            <Card
+              collapsible
+              title="active orders"
+            />
+          </div>
+          <div class="flex flex-col lg:w-1/2">
+            <Card
+              v-if="orderBookIsActive"
+              collapsible
+              title="order book"
+              class="mb-card-margin"
+            >
+              <OrderBook slot="body"/>
+            </Card>
+            <Card
+              :expandable="true"
+              title="My orders history"
+            >
+              <OrderHistorySearch slot="modal-header"/>
+              <OrderHistory slot="body"/>
+              <OrderHistory
+                slot="modal"
+                :expand-mode="true"
+              />
+            </Card>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/src/views/OrderBook/OrderBook.vue
+++ b/src/views/OrderBook/OrderBook.vue
@@ -54,10 +54,10 @@ export default {
       fetching: 'orderBook/isFetching'
     }),
     baseAssetSymbol() {
-      return this.baseAsset && this.baseAsset.symbol
+      return (this.baseAsset && this.baseAsset.symbol) || ''
     },
     quoteAssetSymbol() {
-      return this.quoteAsset && this.quoteAsset.symbol
+      return (this.quoteAsset && this.quoteAsset.symbol) || ''
     }
   }
 }

--- a/src/views/OrderBook/OrderBookTable.vue
+++ b/src/views/OrderBook/OrderBookTable.vue
@@ -12,8 +12,8 @@
       :items="items"
       :headers="tableHeaders"
       :type="tableType"
-      :header-left-padding="tableType === 'buy' ? 0.6 : 0.6"
-      :header-right-padding="tableType === 'sell' ? 0.4 : 0.6"
+      :header-left-padding="tableType === 'buy' ? 1 : 0.6"
+      :header-right-padding="tableType === 'sell' ? 1 : 0.6"
       :default-sort="defaultSort"
     >
       <template slot-scope="{ sortedItems }">
@@ -90,7 +90,7 @@ export default {
     }
   }
   .order-book__column-title {
-    padding: 0 0.4rem 0 0.6rem;
+    padding: 0 1rem;
     margin-bottom: 0.6rem;
     color: config('colors.text-primary');
     // margin-bottom: -0.9375rem;

--- a/src/views/OrderBook/OrderBookTableItem.vue
+++ b/src/views/OrderBook/OrderBookTableItem.vue
@@ -76,7 +76,6 @@ export default {
   .order-book-table-row {
     display: flex;
     font-size: config('textSizes.sm');
-    // font-family: config('fonts.gotham');
     .order-book-table-item {
       padding: 0.3rem 0;
       flex: 1;
@@ -103,7 +102,7 @@ export default {
         margin-right: config('margin.book-item-m');
         padding-right: config('padding.book-item-p');
         .order-book-item-sum {
-          margin-left: config('margin.book-item-m10');
+          margin-left: 1rem;
           float: left;
         }
       }
@@ -125,7 +124,7 @@ export default {
         margin-left: config('margin.book-item-m');
         padding-left:config('padding.book-item-p');
         .order-book-item-sum {
-          margin-right: .5rem;
+          margin-right: 1rem;
           float: right;
         }
       }

--- a/tailwind.js
+++ b/tailwind.js
@@ -556,6 +556,7 @@ module.exports = {
     '48': '12rem',
     '64': '16rem',
     'card-height': '25rem',
+    'card-long-height': '50.625rem',
     'full': '100%',
     'screen': '100vh'
   },


### PR DESCRIPTION
#### What's this PR do?
Enables longer variant of `Card` to be used with `Markets` widget. Also rearranges cards on a dashboard to match design.
#### Where should the reviewer start?
`src/views/Dashboard.vue`
#### How should this be manually tested?
Just open the dashboard
#### Any background context you want to provide?
n/a
#### What are the relevant tickets?
closes #211 
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/4411295/48930284-7e220f80-ef00-11e8-9ebb-c9d08ea1a29f.png)

#### URL
http://staging-ui.trusty.apasia.tech:8080/211-markets-longer-card
#### Questions:
n/a
