### PR TITLE
147 markets improvements

### DIFF
--- a/src/components/TwoLineItem/TwoLineItem.vue
+++ b/src/components/TwoLineItem/TwoLineItem.vue
@@ -3,17 +3,17 @@
     :class="{'two-line-item--expanded': expanded}"
     class="two-line-item"
   >
-    <slot name="top">
-      <div
-        :class="{'two-line-item-top--pt0': paddingOff}"
-        class="two-line-item-top"
-      >
+    <div class="two-line-item-top">
+      <slot name="top">
         {{ top }}
-      </div>
-    </slot>
-    <slot name="bottom">
-      <div class="two-line-item-bottom">{{ bottom }}</div>
-    </slot>
+      </slot>
+    </div>
+    <div class="two-line-item-bottom">
+      <slot name="bottom">
+        {{ bottom }}
+      </slot>
+    </div>
+
   </div>
 </template>
 <script>
@@ -31,26 +31,18 @@ export default {
       type: Boolean,
       default: false
     },
-    paddingOff: {
-      type: Boolean,
-      default: false
-    }
   }
 }
 </script>
 <style lang="scss">
   .two-line-item {
-    letter-spacing: -0.0625rem;
+    letter-spacing: -0.0563rem;
     .two-line-item-top {
       font-size: config('textSizes.lg');
       color: config('colors.primary');
       overflow: hidden;
       word-break: break-all;
       padding-top: .3rem;
-
-      &--pt0 {
-        padding-top: 0;
-      }
     }
     .two-line-item-bottom {
       font-size: config('textSizes.sm');

--- a/src/components/TwoLineItem/TwoLineItem.vue
+++ b/src/components/TwoLineItem/TwoLineItem.vue
@@ -30,7 +30,7 @@ export default {
     expanded: {
       type: Boolean,
       default: false
-    },
+    }
   }
 }
 </script>

--- a/src/components/TwoLineItem/TwoLineItem.vue
+++ b/src/components/TwoLineItem/TwoLineItem.vue
@@ -37,6 +37,7 @@ export default {
 <style lang="scss">
   .two-line-item {
     letter-spacing: -0.0563rem;
+    padding-right: 0.0563rem;
     .two-line-item-top {
       font-size: config('textSizes.lg');
       color: config('colors.primary');

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -44,5 +44,5 @@ export const shortenFiatValue = (value, precision = 1) => {
   if (!value) return 0
   if (value > 10) return Math.floor(value)
   if (value > 0.1) return value.toFixed(precision)
-  return value.toFixed(2)
+  return +value.toFixed(2)
 }

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -3,7 +3,7 @@
 // convert sum to currency format, exapmle: 1 000 000 (use in markets)
 export const getVolumeFormat = sum => sum < 1 ? sum : sum.toString().replace(/(\d)(?=(\d\d\d)+([^\d]|$))/g, '$1 ')
 
-export const removePrefix = (string, prefix) => {
+export const removePrefix = (string, prefix = 'OPEN.') => {
   let trimmed = string
   if (string.substring(0, prefix.length) === prefix) trimmed = string.slice(prefix.length)
   return trimmed
@@ -37,4 +37,12 @@ export const getFloatCurrency = (n) => {
 
   if (value[0] === '0' && value.length > 9) return value.slice(1, 10).toString()
   return value.slice(0, 9) || '0'
+}
+
+// shortens fiat (USD) value
+export const shortenFiatValue = (value, precision = 1) => {
+  if (!value) return 0
+  if (value > 10) return Math.floor(value)
+  if (value > 0.1) return value.toFixed(precision)
+  return value.toFixed(2)
 }

--- a/src/store/modules/marketsMonitor.js
+++ b/src/store/modules/marketsMonitor.js
@@ -25,10 +25,6 @@ const getters = {
   isListFetching: (state, getters, rootState, rootGetters) => {
     const base = getters.getCurrentBase
     const stats = rootGetters['market/getMarketStats']
-    if (base === 'favourites') {
-      const favFetching = Object.keys(state.favourites).some(base => stats[base].fetching)
-      return favFetching
-    }
     return (stats[base] && stats[base].fetching) || false
   },
   getFavouritesList: (state, getters, rootState, rootGetters) => {

--- a/src/store/modules/marketsMonitor.js
+++ b/src/store/modules/marketsMonitor.js
@@ -26,8 +26,8 @@ const getters = {
     const base = getters.getCurrentBase
     const stats = rootGetters['market/getMarketStats']
     if (base === 'favourites') {
-      const favFetching = Object.keys(state.favourites).map(base => stats[base].fetching).find(isFetching => !!isFetching)
-      return !!favFetching
+      const favFetching = Object.keys(state.favourites).some(base => stats[base].fetching)
+      return favFetching
     }
     return (stats[base] && stats[base].fetching) || false
   },

--- a/src/store/modules/marketsMonitor.js
+++ b/src/store/modules/marketsMonitor.js
@@ -1,4 +1,4 @@
-// import config from 'vuex-bitshares/config.js'
+import config from 'vuex-bitshares/config.js'
 const types = {
   UPDATE_FAVOURITES: 'UPDATE_FAVOURITES',
   UPDATE_CURRENT_BASE: 'UPDATE_CURRENT_BASE',
@@ -70,17 +70,13 @@ const mutations = {
 }
 
 const actions = {
-  initialize(store) {
-    const { state } = store
-    actions.setCurrentBase(store, state.currentBase)
-    // const { defaultMarkets } = config
+  initialize({ dispatch }) {
+    const { defaultMarkets } = config
 
-    // Object.keys(defaultMarkets).forEach(base => {
-    //   Object.keys(defaultMarkets[base]).forEach(quote => {
-    //     dispatch('stats/fetchStats', quote, { root: true })
-    //   })
-    // })
-    // fetch additional market stats
+    // fetch market stats
+    Object.keys(defaultMarkets).forEach(base => {
+      dispatch('market/fetchMarketStats', base, { root: true })
+    })
   },
   toggleFavourite({ state, commit, getters }, { base, quote }) {
     const newFavourites = Object.assign({}, state.favourites)

--- a/src/views/Account/PortfolioItem.vue
+++ b/src/views/Account/PortfolioItem.vue
@@ -7,10 +7,10 @@
     <div>
       <div
         v-if="expanded"
-        class="single-item">{{ item.tiker }}</div>
+        class="single-item">{{ formattedTicker }}</div>
       <TwoLineItem
         v-else
-        :top="item.tiker"/>
+        :top="formattedTicker"/>
     </div>
 
     <div
@@ -71,7 +71,7 @@
 
 <script>
 import TwoLineItem from '@/components/TwoLineItem'
-import { getFloatCurrency } from '@/helpers/utils'
+import { getFloatCurrency, shortenFiatValue, removePrefix } from '@/helpers/utils'
 
 export default {
   components: { TwoLineItem },
@@ -96,14 +96,17 @@ export default {
     isPricesMode() {
       return this.mode === 'prices'
     },
+    formattedTicker() {
+      return removePrefix(this.item.tiker)
+    },
     formattedTokens() {
       return getFloatCurrency(this.item.tokens)
     },
     formattedTokenPrice() {
-      return '$' + this.preciseFiatValue(this.item.tokenPrice || 0)
+      return '$' + shortenFiatValue(this.item.tokenPrice || 0)
     },
     formattedFiatValue() {
-      return '$' + this.preciseFiatValue(this.item.fiatValue || 0)
+      return '$' + shortenFiatValue(this.item.fiatValue || 0)
     },
     formattedBtcValue() {
       return getFloatCurrency(this.item.btcValue || 0)
@@ -114,14 +117,6 @@ export default {
       return {
         'grid-template-columns': `repeat(${columns}, 1fr)`
       }
-    }
-  },
-  methods: {
-    preciseFiatValue(value, precision = 1) {
-      if (!value) return 0
-      if (value > 10) return Math.floor(value)
-      if (value > 0.1) return value.toFixed(precision)
-      return value.toFixed(2)
     }
   }
 }

--- a/src/views/ActiveOrders/ActiveOrdersTableItem.vue
+++ b/src/views/ActiveOrders/ActiveOrdersTableItem.vue
@@ -14,8 +14,8 @@
     >
       <div class="table-item">
         <TwoLineItem
-          :top="item.payAssetSymbol"
-          :bottom="item.receiveAssetSymbol"
+          :top="formattedPayAsset"
+          :bottom="formattedReceiveAsset"
         />
       </div>
       <div class="table-item">
@@ -46,8 +46,8 @@
     >
       <div class="table-item">
         <TwoLineItem
-          :top="item.payAssetSymbol"
-          :bottom="item.receiveAssetSymbol"
+          :top="formattedPayAsset"
+          :bottom="formattedReceiveAsset"
           :expanded="expanded"
         />
       </div>
@@ -61,14 +61,14 @@
       <div class="table-item">
         <TwoLineItem
           :top="get"
-          :bottom="item.receiveAssetSymbol"
+          :bottom="formattedReceiveAsset"
           :expanded="expanded"
         />
       </div>
       <div class="table-item _relative">
         <TwoLineItem
           :top="spend"
-          :bottom="item.payAssetSymbol"
+          :bottom="formattedPayAsset"
           :expanded="expanded"
         />
       </div>
@@ -110,7 +110,7 @@
 import { mapActions } from 'vuex'
 import { format } from 'date-fns'
 import '@icons/cancel'
-import { getFloatCurrency } from '@/helpers/utils'
+import { getFloatCurrency, removePrefix } from '@/helpers/utils'
 import TwoLineItem from '@/components/TwoLineItem/TwoLineItem'
 
 export default {
@@ -137,6 +137,12 @@ export default {
     return {}
   },
   computed: {
+    formattedPayAsset() {
+      return removePrefix(this.item.payAssetSymbol)
+    },
+    formattedReceiveAsset() {
+      return removePrefix(this.item.receiveAssetSymbol)
+    },
     dateOpen() {
       return format(this.item.dateOpen, 'DD/MM')
     },

--- a/src/views/Markets/Markets.vue
+++ b/src/views/Markets/Markets.vue
@@ -62,7 +62,6 @@ export default {
       searchStr: 'marketsMonitor/getSearchStr'
     }),
     showLoader() {
-      if (this.favouritesMode) return this.isFetching
       return this.isFetching && !this.itemsList.length
     },
     favouritesMode() {

--- a/src/views/Markets/MarketsList.vue
+++ b/src/views/Markets/MarketsList.vue
@@ -59,7 +59,7 @@ export default {
       marketsField: {
         small: [
           { title: 'Pair', field: 'ticker', align: 'left', paddingLeft: 1.5 },
-          { title: 'Price, USD', field: 'usdPrice', align: 'left' },
+          { title: 'Price, USD', field: 'usdPrice', align: 'right' },
           { title: 'Vol, USD', field: 'usdVolume', align: 'right' },
           { title: '24h', field: 'change24h', align: 'right', secondTitle: '7d', secondField: 'change7d' }
         ],

--- a/src/views/Markets/MarketsListItem.vue
+++ b/src/views/Markets/MarketsListItem.vue
@@ -15,6 +15,7 @@
 import { mapActions } from 'vuex'
 import MarketsListItemPrices from './MarketsListItemPrices'
 import { amountValueShortener } from '@/helpers/utils'
+import round from 'lodash/round'
 
 export default {
   components: { MarketsListItemPrices },
@@ -45,10 +46,10 @@ export default {
       return 0
     },
     changeValue7() {
-      return this.getChangeValue({ price: this.item.change7d })
+      return this.getChangeValue({ price: round(this.item.change7d, 1) })
     },
     changeValue24() {
-      return this.getChangeValue({ price: this.item.change24h })
+      return this.getChangeValue({ price: round(this.item.change24h, 1) })
     }
   },
   methods: {

--- a/src/views/Markets/MarketsListItem.vue
+++ b/src/views/Markets/MarketsListItem.vue
@@ -38,7 +38,7 @@ export default {
   },
   computed: {
     volUsd() {
-      return amountValueShortener(this.item.usdVolume.toFixed(0))
+      return amountValueShortener(this.item.usdVolume)
     },
     marketCap() {
       // return amountValueShortener(this.item.marketcap)

--- a/src/views/Markets/MarketsListItemPrices.vue
+++ b/src/views/Markets/MarketsListItemPrices.vue
@@ -12,17 +12,13 @@
         />
         <TwoLineItem
           :top="formattedTiker"
-          :padding-off="true"
           class="pl-6"
         >
           <span slot="bottom">/{{ formattedBase }}</span>
         </TwoLineItem>
       </div>
-      <div class="tickers-list__item">
-        <TwoLineItem
-          :top="price"
-          :padding-off="true"
-        >
+      <div class="tickers-list__item text-right">
+        <TwoLineItem :top="price">
           <span slot="bottom">${{ formattedUsdPrice }}</span>
         </TwoLineItem>
       </div>
@@ -171,7 +167,7 @@ export default {
   .tickers-list-row {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
-    padding: 0.4375rem 1rem .4375rem .54rem;
+    padding: .2675rem 1rem .4375rem .54rem;
     transition: background 0.2s ease;
     cursor: pointer;
 
@@ -193,12 +189,8 @@ export default {
       color: config('colors.drop');
       opacity: 1;
     }
-    ._flex05 {
-      flex: .7;
-    }
     ._verticalCenter {
-      min-height: 2.125rem;
-      line-height: 2.125rem;
+      align-self: center;
     }
   }
   .ticker-list-row_expanded {

--- a/src/views/Markets/MarketsListItemPrices.vue
+++ b/src/views/Markets/MarketsListItemPrices.vue
@@ -11,11 +11,11 @@
           @click.stop.native="$emit('change', { item })"
         />
         <TwoLineItem
-          :top="item.ticker"
+          :top="formattedTiker"
           :padding-off="true"
           class="pl-6"
         >
-          <span slot="bottom">/{{ item.base }}</span>
+          <span slot="bottom">/{{ formattedBase }}</span>
         </TwoLineItem>
       </div>
       <div class="tickers-list__item">
@@ -23,7 +23,7 @@
           :top="price"
           :padding-off="true"
         >
-          <span slot="bottom">${{ item.usdPrice }}</span>
+          <span slot="bottom">${{ formattedUsdPrice }}</span>
         </TwoLineItem>
       </div>
       <div class="tickers-list__item text-right _verticalCenter">
@@ -49,8 +49,8 @@
           @click.native="$emit('change', { item })"
         />
         <div class="tickers-list__itemPair">
-          <span class="_currencyTitle pl-6">{{ item.ticker }}</span>
-          <span class="_tickerTitle">/{{ item.base }}</span>
+          <span class="_currencyTitle pl-6">{{ formattedTiker }}</span>
+          <span class="_tickerTitle">/{{ formattedBase }}</span>
         </div>
       </div>
       <div class="tickers-list__item">
@@ -82,7 +82,7 @@
 <script>
 import Star from '@/components/Star'
 import TwoLineItem from '@/components/TwoLineItem/TwoLineItem'
-import { getFloatCurrency } from '@/helpers/utils'
+import { getFloatCurrency, shortenFiatValue, removePrefix } from '@/helpers/utils'
 
 export default {
   components: {
@@ -122,6 +122,15 @@ export default {
   computed: {
     price() {
       return getFloatCurrency(this.item.price)
+    },
+    formattedTiker() {
+      return removePrefix(this.item.ticker)
+    },
+    formattedBase() {
+      return removePrefix(this.item.base)
+    },
+    formattedUsdPrice() {
+      return shortenFiatValue(this.item.usdPrice)
     }
   },
   methods: {

--- a/src/views/OrderBook/OrderBook.vue
+++ b/src/views/OrderBook/OrderBook.vue
@@ -26,6 +26,7 @@ import { mapGetters } from 'vuex'
 import OrderBookTable from './OrderBookTable'
 import OrderBookLastPrice from './OrderBookLastPrice'
 import LoadingContainer from '@/components/LoadingContainer'
+import { removePrefix } from '@/helpers/utils'
 
 export default {
   components: {
@@ -54,10 +55,10 @@ export default {
       fetching: 'orderBook/isFetching'
     }),
     baseAssetSymbol() {
-      return (this.baseAsset && this.baseAsset.symbol) || ''
+      return removePrefix((this.baseAsset && this.baseAsset.symbol) || '')
     },
     quoteAssetSymbol() {
-      return (this.quoteAsset && this.quoteAsset.symbol) || ''
+      return removePrefix((this.quoteAsset && this.quoteAsset.symbol) || '')
     }
   }
 }

--- a/src/views/OrderHistory/OrderHistoryTableItem.vue
+++ b/src/views/OrderHistory/OrderHistoryTableItem.vue
@@ -13,8 +13,8 @@
     >
       <div class="table-item">
         <TwoLineItem
-          :top="item.payAssetSymbol"
-          :bottom="item.receiveAssetSymbol"
+          :top="formattedPayAsset"
+          :bottom="formattedReceiveAsset"
         />
       </div>
       <div class="table-item">
@@ -37,8 +37,8 @@
     >
       <div class="table-item">
         <TwoLineItem
-          :top="item.payAssetSymbol"
-          :bottom="item.receiveAssetSymbol"
+          :top="formattedPayAsset"
+          :bottom="formattedReceiveAsset"
           :expanded="expanded"
         />
       </div>
@@ -52,14 +52,14 @@
       <div class="table-item">
         <TwoLineItem
           :top="get"
-          :bottom="item.receiveAssetSymbol"
+          :bottom="formattedReceiveAsset"
           :expanded="expanded"
         />
       </div>
       <div class="table-item">
         <TwoLineItem
           :top="spend"
-          :bottom="item.payAssetSymbol"
+          :bottom="formattedPayAsset"
           :expanded="expanded"
         />
       </div>
@@ -76,7 +76,7 @@
 </template>
 <script>
 import { format } from 'date-fns'
-import { getFloatCurrency } from '@/helpers/utils'
+import { getFloatCurrency, removePrefix } from '@/helpers/utils'
 import TwoLineItem from '@/components/TwoLineItem'
 
 export default {
@@ -99,6 +99,12 @@ export default {
     return {}
   },
   computed: {
+    formattedPayAsset() {
+      return removePrefix(this.item.payAssetSymbol)
+    },
+    formattedReceiveAsset() {
+      return removePrefix(this.item.receiveAssetSymbol)
+    },
     dateOpen() {
       return format(this.item.dateOpen, 'DD/MM')
     },


### PR DESCRIPTION
#### What's this PR do?
Improves Markets widget behaviour: less loaders when they are not needed, fix 7d% glitching (vuex-bitshares), improved widget layout, assets prefix shortening and improved usd value formatting
#### Where should the reviewer start?
`src/views/Markets`
#### How should this be manually tested?
n/a
#### Any background context you want to provide?
n/a
#### What are the relevant tickets?
closes #147 
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/4411295/49328467-760e4380-f582-11e8-87f8-f0d23fc168fd.png)
#### URL
http://staging-ui.trusty.apasia.tech:8080/branch-branch-147-markets-improvements
#### Questions:
n/a
