### PR TITLE
#306 disable sort in table

### DIFF
--- a/src/components/SortableHeaderItem/SortableHeaderItem.vue
+++ b/src/components/SortableHeaderItem/SortableHeaderItem.vue
@@ -133,6 +133,9 @@ export default {
   &--large {
     font-size: config('textSizes.base');
   }
+  &--disabled {
+    cursor: default;
+  }
 }
 
 .header-item__title {

--- a/src/components/SortableTable/SortableTable.vue
+++ b/src/components/SortableTable/SortableTable.vue
@@ -15,7 +15,7 @@
         :large="large"
         :disable-sort="header.disableSort"
         :class="{ headerDisabled : header.disableSort }"
-        @change="header.disableSort ? () => {} : toggleSort"
+        @change="toggleSort(sort.field, header)"
       />
     </div>
     <slot name="row"/>
@@ -102,7 +102,10 @@ export default {
     this.sort = this.defaultSort
   },
   methods: {
-    toggleSort(field) {
+    toggleSort(field, header) {
+      console.log('toggleSort')
+      console.log(header)
+      if (header.disableSort) return
       if (this.sort.field === field) {
         this.sort.type = this.sort.type === 'asc' ? 'desc' : 'asc'
         return

--- a/src/components/SortableTable/SortableTable.vue
+++ b/src/components/SortableTable/SortableTable.vue
@@ -14,7 +14,7 @@
         :padding-left="header.paddingLeft"
         :large="large"
         :disable-sort="header.disableSort"
-        :class="{ headerDisabled : header.disableSort }"
+        :class="{ 'header-item--disabled' : header.disableSort }"
         @change="toggleSort(sort.field, header)"
       />
     </div>
@@ -132,8 +132,5 @@ export default {
     padding-top: config('padding.2');
     height: 100%;
     overflow: auto;
-  }
-  .headerDisabled {
-    cursor: default !important;
   }
 </style>

--- a/src/components/SortableTable/SortableTable.vue
+++ b/src/components/SortableTable/SortableTable.vue
@@ -13,7 +13,9 @@
         :align="header.align"
         :padding-left="header.paddingLeft"
         :large="large"
-        @change="toggleSort"
+        :disable-sort="header.disableSort"
+        :class="{ headerDisabled : header.disableSort }"
+        @change="header.disableSort ? () => {} : toggleSort"
       />
     </div>
     <slot name="row"/>
@@ -129,5 +131,8 @@ export default {
     padding-top: config('padding.2');
     height: 100%;
     overflow: auto;
+  }
+  .headerDisabled {
+    cursor: default !important;
   }
 </style>

--- a/src/components/SortableTable/SortableTable.vue
+++ b/src/components/SortableTable/SortableTable.vue
@@ -103,8 +103,6 @@ export default {
   },
   methods: {
     toggleSort(field, header) {
-      console.log('toggleSort')
-      console.log(header)
       if (header.disableSort) return
       if (this.sort.field === field) {
         this.sort.type = this.sort.type === 'asc' ? 'desc' : 'asc'

--- a/src/views/OrderBook/OrderBook.vue
+++ b/src/views/OrderBook/OrderBook.vue
@@ -41,12 +41,12 @@ export default {
     tableHeaders() {
       return {
         buy: [
-          { title: `Sum, ${this.baseAssetSymbol}`, field: 'sum', align: 'left' },
+          { title: `Sum, ${this.baseAssetSymbol}`, field: 'sum', align: 'left', disableSort: true },
           { title: ``, field: 'price' }
         ],
         sell: [
           { title: ``, field: 'price', align: 'left' },
-          { title: `Sum, ${this.baseAssetSymbol}`, field: 'sum' }
+          { title: `Sum, ${this.baseAssetSymbol}`, field: 'sum', disableSort: true }
         ]
       }
     },


### PR DESCRIPTION
#### What's this PR do?
- Implements new property on header columns that will enable/disable the sorting of the column
- Enforces the default cursor for a disabled header, indicating no available click.

#### Where should the reviewer start?
- SortableTable.vue

#### How should this be manually tested?
- Make sure the OrderBook tables sorting functionality can be enabled/disabled by toggling the sortDisabled value passed in OrderBook.vue

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### URL
[http://staging-ui.trusty.apasia.tech:8080/branch-306DisableSortInTable](http://staging-ui.trusty.apasia.tech:8080/branch-306DisableSortInTable)
#### Questions:
- Does the Trusty team have any restrictions on the use of the ```!important``` flag on css rules?
