### PR TITLE
add asset fullname to withdraw and account

### DIFF
--- a/src/store/modules/portfolio.js
+++ b/src/store/modules/portfolio.js
@@ -62,11 +62,16 @@ const getters = {
       const tokenPrice = fiatValue / tokens
       const change7 = getters.getPriceChangeById({ assetId, days: 7 })
       const change1 = getters.getPriceChangeById({ assetId, days: 1 })
+      // let tiker = asset.symbol
+      // if (asset.fullname) {
+      //   tiker += ' (' + asset.fullname + ')'
+      // }
 
       const share = Math.round((baseValue / getters.getTotalBaseValue) * 100)
       return {
         assetId,
         tiker: asset.symbol,
+        fullname: asset.fullname,
         tokens,
         fiatValue,
         btcValue,

--- a/src/store/modules/portfolio.js
+++ b/src/store/modules/portfolio.js
@@ -62,10 +62,6 @@ const getters = {
       const tokenPrice = fiatValue / tokens
       const change7 = getters.getPriceChangeById({ assetId, days: 7 })
       const change1 = getters.getPriceChangeById({ assetId, days: 1 })
-      // let tiker = asset.symbol
-      // if (asset.fullname) {
-      //   tiker += ' (' + asset.fullname + ')'
-      // }
 
       const share = Math.round((baseValue / getters.getTotalBaseValue) * 100)
       return {

--- a/src/views/Account/PortfolioItem.vue
+++ b/src/views/Account/PortfolioItem.vue
@@ -10,7 +10,8 @@
         class="single-item">{{ formattedTicker }}</div>
       <TwoLineItem
         v-else
-        :top="formattedTicker"/>
+        :top="formattedTicker"
+        :bottom="formattedFullname"/>
     </div>
 
     <div
@@ -98,6 +99,9 @@ export default {
     },
     formattedTicker() {
       return removePrefix(this.item.tiker)
+    },
+    formattedFullname() {
+      return this.item.fullname
     },
     formattedTokens() {
       return getFloatCurrency(this.item.tokens)

--- a/src/views/Withdraw/Withdraw.vue
+++ b/src/views/Withdraw/Withdraw.vue
@@ -12,7 +12,7 @@
               <Button
                 v-for="(asset, index) in coinslist"
                 :key="index"
-                :text="asset.tiker"
+                :text="asset.tickerName"
                 type="secondary"
                 width="full"
                 class="withdraw-item"
@@ -44,7 +44,13 @@ export default {
     }),
     coinslist() {
       // this.getAssetBySymbol(coin.tiker).issuer === coin.assetId
-      return this.coins.filter(coin => coin.tokens)
+      return (this.coins.filter(coin => coin.tokens)).map(coin => {
+        coin.tickerName = coin.tiker
+        if (coin.fullname) {
+          coin.tickerName += ' (' + coin.fullname + ')'
+        }
+        return coin
+      })
     }
   },
   methods: {


### PR DESCRIPTION
#### What's this PR do?
Show fullname of assets
#### Where should the reviewer start?
src/store/modules/portfolio.js: 70
#### How should this be manually tested?
See fullname of assets in withdraw and account windows
#### Any background context you want to provide?
merge after https://github.com/bitshares/vuex-bitshares/pull/68
#### What are the relevant tickets?
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/17277287/50374840-64f6a680-0605-11e9-8888-a07f698f50eb.png)
![image](https://user-images.githubusercontent.com/17277287/50374851-75a71c80-0605-11e9-99cc-922044801e2b.png)
#### URL
Provide a link to your deploy from http://staging-ui.trusty.apasia.tech:8080/branch-assets-fullname
#### Questions:
